### PR TITLE
[STACK-2569][STACK-2570][STACK-2581] Delete post migrate and device name support

### DIFF
--- a/a10_nlbaas2oct/a10_config.py
+++ b/a10_nlbaas2oct/a10_config.py
@@ -55,14 +55,18 @@ class ConfigModule(object):
 
 class A10Config(object):
 
-    def __init__(self, config_dir=None, config=None, provider=None):
+    def __init__(self, config_dir=None, config_path=None, config=None, provider=None):
         if config is not None:
             self._config = config
             self._load_config()
             return
 
-        self._config_dir = self._find_config_dir(config_dir)
-        self._config_path = os.path.join(self._config_dir, "config.py")
+
+        if not config_path:
+            self._config_dir = self._find_config_dir(config_dir)
+            self._config_path = os.path.join(self._config_dir, "config.py")
+        else:
+            self._config_path = config_path
 
         try:
             self._config = ConfigModule.load(self._config_path, provider=provider)

--- a/a10_nlbaas2oct/flavor_migration.py
+++ b/a10_nlbaas2oct/flavor_migration.py
@@ -12,12 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import datetime
-import sys
-
-from oslo_db.sqlalchemy import enginefacade
-import oslo_i18n as i18n
-from oslo_log import log as logging
 from oslo_utils import uuidutils
 
 
@@ -29,8 +23,8 @@ def _create_flavor_expr(expr_data):
     return name_exprs
 
 
-def create_flavor_data(a10_config):
-    flavor_data = {}
+def create_flavor_data(a10_config, device_name):
+    flavor_data = {'device-name': device_name}
 
     vs_expr = a10_config.get_virtual_server_expressions()
     if vs_expr:


### PR DESCRIPTION
[STACK-2569](https://a10networks.atlassian.net/browse/STACK-2569) - Added a separate cleanup CLI option that can be run after a migration has occurred or during.

[STACK-2570](https://a10networks.atlassian.net/browse/STACK-2570) - Added device-name to flavor migration to allow for usage via a10-octavia

[STACK-2581](https://a10networks.atlassian.net/browse/STACK-2581) - Allowed for config file names other than config.py to be specified