### PR TITLE
[STACK-2583]: Failed to migrate LB from a10-neutron-lbaas to a10-octavia(for new changes)

### DIFF
--- a/a10_nlbaas2oct/a10_migration.py
+++ b/a10_nlbaas2oct/a10_migration.py
@@ -14,10 +14,10 @@
 
 import datetime
 try:
-    import functools as functools
-except:
-    # py27 backwards compatability
+    # for python3 exception raised
     import functools32 as functools
+except:
+    import functools
 import oslo_i18n as i18n
 from oslo_utils import uuidutils
 

--- a/a10_nlbaas2oct/a10_migration.py
+++ b/a10_nlbaas2oct/a10_migration.py
@@ -18,7 +18,6 @@ try:
 except:
     # py27 backwards compatability
     import functools32 as functools
-
 import oslo_i18n as i18n
 from oslo_utils import uuidutils
 


### PR DESCRIPTION
python2.7 has has functools module which don't have lru_cache method. 