### PR TITLE
[STACK-2584][STACK-2585] Implemented stricter check on CONF.all

### DIFF
--- a/a10_nlbaas2oct/db_utils.py
+++ b/a10_nlbaas2oct/db_utils.py
@@ -42,7 +42,7 @@ def unlock_loadbalancer(n_session, lb_id):
         "provisioning_status = 'PENDING_UPDATE';", {'id': lb_id})
 
 
-def get_loadbalancer_ids(n_session, conf_lb_id_list=[], conf_project_id=None):
+def get_loadbalancer_ids(n_session, conf_lb_id_list=[], conf_project_id=None, conf_all=False):
     lb_id_list = []
     if conf_lb_id_list:
         for conf_lb_id in conf_lb_id_list:
@@ -68,7 +68,7 @@ def get_loadbalancer_ids(n_session, conf_lb_id_list=[], conf_project_id=None):
             "SELECT id FROM neutron.lbaas_loadbalancers WHERE "
             "project_id = :id AND provisioning_status = 'ACTIVE';",
             {'id': conf_project_id}).fetchall()
-    else:  # CONF.ALL
+    elif conf_all:
         lb_id_list = n_session.execute(
             "SELECT id FROM neutron.lbaas_loadbalancers WHERE "
             "provisioning_status = 'ACTIVE';").fetchall()

--- a/a10_nlbaas2oct/driver.py
+++ b/a10_nlbaas2oct/driver.py
@@ -284,13 +284,13 @@ def _setup_db_sessions():
 
 
 def _cleanup_confirmation(LOG):
-    print("WARNING: This is a destructive action. Neutron LBaaS entires will be permanently deleteind")
+    print("\nWARNING: Executing with --cleanup is a destructive action. Specified loadbalancers and child objects will be permanently deleted.")
     full_success_msg = None
     lb_success_msg = None
 
     resp = None
     while resp != "no" and resp != "yes":
-        resp = input("Are you sure you want to delete? [yes/no]")
+        resp = input("Are you sure you want to delete them? [yes/no]: ")
         resp = resp.lower()
         if resp == "no":
             return None, None

--- a/a10_nlbaas2oct/driver.py
+++ b/a10_nlbaas2oct/driver.py
@@ -352,10 +352,15 @@ def main():
                                    provider=CONF.migration.provider_name)
 
     conf_lb_id_list = CONF.migration.lb_id_list
-    if CONF.lb_id and conf_lb_id_list:
+    if not conf_lb_id_list:
+        conf_lb_id_list = []
+
+    if CONF.lb_id:
         conf_lb_id_list.append(CONF.lb_id)
+    
     lb_id_list = db_utils.get_loadbalancer_ids(n_session, conf_lb_id_list=conf_lb_id_list,
-                                               conf_project_id=CONF.project_id)
+                                               conf_project_id=CONF.project_id,
+                                               conf_all=CONF.all)
     fl_id = None
     failure_count = 0
     tenant_bindings = []


### PR DESCRIPTION
## Description
If `lb_id_list` was not specified in the config file, then the `lb_id` would not be appended. Therefore, it would send a None to the `get_loadbalancer_ids` function. The `get_loadbalancer_ids` defaulted to CONF.all therefore all lbs were getting migrated.

## JIRA tickets
[STACK-2584](https://a10networks.atlassian.net/browse/STACK-2584)
[STACK-2585](https://a10networks.atlassian.net/browse/STACK-2585)

## Technical approach
- Added a check for CONF.all. Default behavior is now to do nothing.
- Defaulted `conf_lb_id_list` to an empty list in the case that it is not specified in the config