### PR TITLE
[STACK-2647] HMT with use_parent_partition member delete failed after migration

### DIFF
--- a/a10_nlbaas2oct/db_utils.py
+++ b/a10_nlbaas2oct/db_utils.py
@@ -156,7 +156,7 @@ def get_sess_pers_by_pool(n_session, pool_id):
 def get_members_by_pool(n_session, pool_id):
     members = n_session.execute(
         "SELECT id, subnet_id, address, protocol_port, weight, "
-        "admin_state_up, provisioning_status, operating_status, name FROM "
+        "admin_state_up, provisioning_status, operating_status, name, project_id FROM "
         "lbaas_members WHERE pool_id = :pool_id;",
         {'pool_id': pool_id}).fetchall()
     return members

--- a/a10_nlbaas2oct/lbaas_migration.py
+++ b/a10_nlbaas2oct/lbaas_migration.py
@@ -282,7 +282,7 @@ def migrate_member(o_session, project_id, pool_id, member):
         "VALUES (:id, :pool_id, :project_id, :subnet_id, :ip_address, "
         ":protocol_port, :weight, :operating_status, :enabled, "
         ":created_at, :updated_at, :provisioning_status, :name, :backup);",
-        {'id': member[0], 'pool_id': pool_id, 'project_id': project_id,
+        {'id': member[0], 'pool_id': pool_id, 'project_id': member[9],
          'subnet_id': member[1], 'ip_address': member[2],
          'protocol_port': member[3], 'weight': member[4],
          'operating_status': member[7], 'enabled': member[5],


### PR DESCRIPTION
**[Description]**
Using HMT with use_parent_partition, member didn't deleted in Thunder.

We can still see following conf in thunder after cascade deletion:
```
slb server _a3632_10_0_11_121_neutron 10.0.11.121
  conn-limit 8000000
  port 443 tcp
!
slb server _a3632_10_0_11_123_neutron 10.0.11.123
  conn-limit 8000000
  port 80 tcp
!
```
-------------

**[Issue link]**
https://a10networks.atlassian.net/browse/STACK-2647

-------------

**[Root Cause]**
In neutron-lbaas when member is created child project, the project_id in database is using parent project:
```
mysql> select * from lbaas_members;
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+----------------+---------------------+------------------+---------+
| project_id                       | id                                   | pool_id                              | subnet_id                            | address     | protocol_port | weight | admin_state_up | provisioning_status | operating_status | name    |
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+----------------+---------------------+------------------+---------+
| a36327f793ad45a8b7824100b15e681a | 895db665-438a-4d38-aa45-499f4b7cee8b | cc89f4b5-dfe4-428a-adad-701708fee45a | ff1cca0b-d8a8-4526-97d1-e76eb7d7f8f9 | 10.0.11.123 |            80 |      1 |              1 | ACTIVE              | ONLINE           | m121443 |
| a36327f793ad45a8b7824100b15e681a | a308da1b-7018-4daa-8b49-aa15865c7de6 | a8741c95-c5d3-4d19-a989-17d51890b2b0 | ff1cca0b-d8a8-4526-97d1-e76eb7d7f8f9 | 10.0.11.121 |           443 |      1 |              1 | ACTIVE              | ONLINE           | m121443 |
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+----------------+---------------------+------------------+---------+
2 rows in set (0.00 sec)
```

But after migration, in octavia database it using child project as project_id
```
mysql> select * from member;
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+------------------+---------+---------------------+---------------------+---------------------+---------+-----------------+--------------+--------+
| project_id                       | id                                   | pool_id                              | subnet_id                            | ip_address  | protocol_port | weight | operating_status | enabled | created_at          | updated_at          | provisioning_status | name    | monitor_address | monitor_port | backup |
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+------------------+---------+---------------------+---------------------+---------------------+---------+-----------------+--------------+--------+
| aabd9be021014963a275f0c5d92a5544 | 895db665-438a-4d38-aa45-499f4b7cee8b | cc89f4b5-dfe4-428a-adad-701708fee45a | ff1cca0b-d8a8-4526-97d1-e76eb7d7f8f9 | 10.0.11.123 |            80 |      1 | ONLINE           |       1 | 2021-07-22 07:25:52 | 2021-07-22 07:25:52 | ACTIVE              | m121443 | NULL            |         NULL |      0 |
| aabd9be021014963a275f0c5d92a5544 | a308da1b-7018-4daa-8b49-aa15865c7de6 | a8741c95-c5d3-4d19-a989-17d51890b2b0 | ff1cca0b-d8a8-4526-97d1-e76eb7d7f8f9 | 10.0.11.121 |           443 |      1 | ONLINE           |       1 | 2021-07-22 07:25:52 | 2021-07-22 07:25:52 | ACTIVE              | m121443 | NULL            |         NULL |      0 |
+----------------------------------+--------------------------------------+--------------------------------------+--------------------------------------+-------------+---------------+--------+------------------+---------+---------------------+---------------------+---------------------+---------+-----------------+--------------+--------+
2 rows in set (0.00 sec)
```

-------------

**[Solution]**
In migration tool, we should use same project_id in database, not the project_id in the option.

-------------

**[Test case]**

```
neutron lbaas-loadbalancer-create --name lb3 provider-vlan-11-subnet --tenant-id aabd9be021014963a275f0c5d92a5544
neutron lbaas-listener-create --protocol HTTPS --protocol-port 443 --name li3-443 --loadbalancer lb3
neutron lbaas-listener-create --protocol tcp --protocol-port 80 --name li3-80 --loadbalancer lb3
neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --protocol https --name pi3-443 --listener li3-443
neutron lbaas-pool-create --lb-algorithm ROUND_ROBIN --protocol tcp --name pi3-80 --listener li3-80
neutron lbaas-member-create --protocol-port 443 --subnet provider-vlan-11-subnet --address 10.0.11.121 --name m121443 pi3-443
neutron lbaas-member-create --protocol-port 80 --subnet provider-vlan-11-subnet --address 10.0.11.123 --name m121443 pi3-80

a10_nlbaas2oct --config-file a10-nlbaas2oct/a10_nlbaas2oct/a10_nlbaas2oct.conf --project-id aabd9be021014963a275f0c5d92a5544
a10_nlbaas2oct --config-file a10-nlbaas2oct/a10_nlbaas2oct/a10_nlbaas2oct.conf --project-id aabd9be021014963a275f0c5d92a5544 --cleanup

openstack loadbalancer delete lb3 --cascade
```

-------------

**[Result]**

```
stack@qa-120:~#openstack loadbalancer delete lb3 --cascade
stack@qa-120:~#openstack loadbalancer list

stack@qa-120:~#

```

```
vThunder-Active-vMaster[11/1][a36327f793ad4](config:1)(NOLICENSE)#show running-config
!Current configuration: 57 bytes
!Configuration last updated at 08:30:41 IST Thu Jul 22 2021
!Configuration last saved at 07:43:53 IST Thu Jul 22 2021
!
active-partition a36327f793ad4
!
!
vlan 1/12
  tagged ethernet 2
  router-interface ve 12
!
interface ve 1/12
  ip address 10.0.12.12 255.255.255.0
!
!
end
!Current config commit point for partition 1 is 0 & config mode is classical-mode
vThunder-Active-vMaster[11/1][a36327f793ad4](config:1)(NOLICENSE)#
```