### PR TITLE
[STACK-2763]: Added support for allowing flavor-id specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ octavia_db_connection =
 # Connection string for the A10 database used in the octavia env
 # a10_oct_connection =
 
+# Default flavor-id that will be used for the loadbalancer in the run
+# default_flavor_id =
+
+# Comma seperated list of loadbalancer ids to migrate or cleanup
+# lb_id_list =
+
+# Comma separated list of flavor ids that will be used in parallel with the entries in lb_id_list
+# flavor_id_list =
+
 # Path to config file. Default is /etc/a10/config.py
 a10_config_path = /etc/a10/config.py
 ```
@@ -195,6 +204,11 @@ a10_nlbaas2oct --config-file /path/to/a10_nlbaas2oct.conf --project-id <project_
 ### Migrate all lbaas objects
 ```
 a10_nlbaas2oct --config-file /path/to/a10_nlbaas2oct.conf --all
+```
+
+### Migrate a single loadbalancer with `--flavor-id` option
+```
+a10_nlbaas2oct --config-file /path/to/a10_nlbaas2oct.conf --lb-id <loadbalancer_id> --flavor-id <flavor_id>
 ```
 
 ## Step 4*: Cleanup post migration

--- a/a10_nlbaas2oct/a10_nlbaas2oct.conf
+++ b/a10_nlbaas2oct/a10_nlbaas2oct.conf
@@ -39,8 +39,14 @@ octavia_db_connection =
 # LBaaS service provider name. Use lowercase. Default is a10networks
 # provider_name = 
 
+# Default flavor-id that will be used for the loadbalancer in the run
+# default_flavor_id = 
+
 # Comma seperated list of loadbalancer ids to migrate or cleanup
 # lb_id_list = 
+
+# Comma separated list of flavor ids that will be used in parallel with the entries in lb_id_list
+# flavor_id_list = 
 
 # Workaround for the l7rule provisioning status issue in a10-neutron-lbaas.
 # Only affects a10-neutron-lbaas version > 1.7.3

--- a/a10_nlbaas2oct/db_utils.py
+++ b/a10_nlbaas2oct/db_utils.py
@@ -264,6 +264,9 @@ def get_tenant_by_name(k_session, name):
 
 def get_flavor_id(o_session, conf_flavor_id):
     # Get flavor id from octavia DB
+    flavor_id_list = []
     flavor_id = o_session.execute(
         "SELECT id FROM octavia.flavor WHERE id = :id;", {'id': conf_flavor_id}).fetchone()
-    return flavor_id
+    if flavor_id:
+        flavor_id_list.append(flavor_id[0])
+    return flavor_id_list

--- a/a10_nlbaas2oct/db_utils.py
+++ b/a10_nlbaas2oct/db_utils.py
@@ -260,3 +260,10 @@ def get_tenant_by_name(k_session, name):
     tenant = k_session.execute(
         "SELECT id FROM project WHERE name = :name;", {'name': name}).fetchall()
     return tenant
+
+
+def get_flavor_id(o_session, conf_flavor_id):
+    # Get flavor id from octavia DB
+    flavor_id = o_session.execute(
+        "SELECT id FROM octavia.flavor WHERE id = :id;", {'id': conf_flavor_id}).fetchone()
+    return flavor_id

--- a/a10_nlbaas2oct/driver.py
+++ b/a10_nlbaas2oct/driver.py
@@ -43,6 +43,8 @@ cli_opts = [
                help='Migrate all load balancers owned by this project'),
     cfg.BoolOpt('cleanup', default=False,
                help='Delete Neutron LBaaS db entries'),
+    cfg.StrOpt('flavor-id',
+               help='Flavor ID to migrate with the specified lb-id'),
 ]
 
 migration_opts = [
@@ -78,26 +80,40 @@ migration_opts = [
                 help='Name of LBaaS service provider'),
     cfg.BoolOpt('ignore_l7rule_status', default=False,
                 required=True,
-                help='Migrate all pending create l7rules')
+                help='Migrate all pending create l7rules'),
+    cfg.StrOpt('default_flavor_id', required=False,
+               help='Default flavor-id that will be used for each loadbalancer in the run')
 ]
 
 cfg.CONF.register_cli_opts(cli_opts)
 cfg.CONF.register_opts(migration_opts, group='migration')
 
 
-def _migrate_flavor(LOG, a10_config, o_session, device_name):
+def _migrate_flavor(LOG, a10_config, o_session, device_name, conf_flavor_id_list):
     # Translate the name expressions into an Octavia flavor
     LOG.info('Migrating name expressions to flavors')
-    fl_id = None
+    fl_id = []
     try:
-        flavor_data = nexpr2fl.create_flavor_data(a10_config, device_name)
-        if flavor_data:
-            fp_id = nexpr2fl.create_flavorprofile(o_session, flavor_data)
-            fl_id = nexpr2fl.create_flavor(o_session, fp_id)
+        if conf_flavor_id_list:
+            for conf_flavor_id in conf_flavor_id_list:
+                fl_id = db_utils.get_flavor_id(o_session, conf_flavor_id)
+                if fl_id:
+                    return fl_id
+                else:
+                    flavor_data = nexpr2fl.create_flavor_data(a10_config, device_name)
+                    if flavor_data:
+                        fp_id = nexpr2fl.create_flavorprofile(o_session, flavor_data)
+                        fl_id = [nexpr2fl.create_flavor(o_session, fp_id, conf_flavor_id)]
+                    return fl_id
+        else:
+            flavor_data = nexpr2fl.create_flavor_data(a10_config, device_name)
+            if flavor_data:
+                fp_id = nexpr2fl.create_flavorprofile(o_session, flavor_data)
+                fl_id = [nexpr2fl.create_flavor(o_session, fp_id, conf_flavor_id_list)]
+            return fl_id
     except Exception as e:
         LOG.exception("Skipping flavor migration due to: %s.", str(e))
         raise Exception
-    return fl_id
 
 
 def _migrate_device(LOG, a10_config, db_sessions, lb_id, tenant_id, tenant_device_binding):
@@ -340,10 +356,18 @@ def main():
 
     XOR_CLI_COMMANDS = (CONF.all, CONF.lb_id, CONF.project_id)
 
+    if CONF.flavor_id and not CONF.lb_id:
+        print('Error: --lb-id should be specified with --flavor-id')
+        return 1
+
     if not any(XOR_CLI_COMMANDS) and not CONF.migration.lb_id_list:
         print('Error: One of --all, --lb-id, --project-id must be '
               'specified or lb_id_list must be set in the config file.')
-        return 1        
+        return 1
+
+    if CONF.flavor_id and (XOR_CLI_COMMANDS[0] or XOR_CLI_COMMANDS[2]):
+        print('Error: --flavor-id can only be used in conjunction with --lb-id')
+        return 1
 
     check_multi = lambda x: bool(x)
     commands = list(filter(check_multi, XOR_CLI_COMMANDS))
@@ -390,6 +414,14 @@ def main():
     lb_id_list = db_utils.get_loadbalancer_ids(n_session, conf_lb_id_list=conf_lb_id_list,
                                                conf_project_id=CONF.project_id,
                                                conf_all=CONF.all)
+
+    conf_flavor_id = []
+    if CONF.flavor_id:
+        conf_flavor_id.append(CONF.flavor_id)
+
+    elif CONF.migration.default_flavor_id:
+        conf_flavor_id.append(CONF.migration.default_flavor_id)
+
     fl_id = None
     failure_count = 0
     tenant_bindings = []
@@ -435,10 +467,11 @@ def main():
                     continue
                 device_name = device_info['name']
                 if device_name != curr_device_name:
-                    fl_id = _migrate_flavor(LOG, a10_config, o_session, device_name)
+                    fl_id_list = _migrate_flavor(LOG, a10_config, o_session, device_name, conf_flavor_id)
                     curr_device_name = device_name
-                _migrate_slb(LOG, n_session, o_session, lb_id,
-                             fl_id, tenant_id, n_lb, CONF.migration.ignore_l7rule_status)
+                for fl_id in fl_id_list:
+                    _migrate_slb(LOG, n_session, o_session, lb_id,
+                                 fl_id, tenant_id, n_lb, CONF.migration.ignore_l7rule_status)
             _cleanup_slb(LOG, n_session, lb_id, CLEANUP_ONLY)
 
             # Rollback everything if we are in a trial run otherwise commit

--- a/a10_nlbaas2oct/driver.py
+++ b/a10_nlbaas2oct/driver.py
@@ -509,7 +509,10 @@ def main():
                         n_session.commit()
                         LOG.info('Successful ' + lb_success_msg, lb_id)
                 else:
-                    full_success_msg = "Skipping the migration as the specified flavor cannot be found"
+                    o_session.rollback()
+                    n_session.rollback()
+                    LOG.warning("Skipping the migration as the specified flavor cannot be found")
+                    return
 
             _cleanup_slb(LOG, n_session, lb_id, CLEANUP_ONLY)
 

--- a/a10_nlbaas2oct/flavor_migration.py
+++ b/a10_nlbaas2oct/flavor_migration.py
@@ -67,8 +67,8 @@ def create_flavorprofile(o_session, flavor_data):
     return flavorprofile_id
 
 
-def create_flavor(o_session, flavorprofile_id):
-    flavor_id = uuidutils.generate_uuid()
+def create_flavor(o_session, flavorprofile_id, conf_flavor_id):
+    flavor_id = conf_flavor_id if conf_flavor_id else uuidutils.generate_uuid()
     flavor_name = flavor_id[:10]
 
     result = o_session.execute(


### PR DESCRIPTION
## Description
Added support for flavor-id specification during migration by **--flavor-id** cli-option and **default_flavor_id** and **flavor_id_list** config-options.

## Jira Ticket
https://a10networks.atlassian.net/browse/STACK-2763

## Technical Approach
- Added a DB method `get_flavor_id()` which will return flavor-id, if the specified flavor_id  is present in Octavia.
- Modified `_migrate_flavor()` method to return flavor-ids as per below conditions:
        - Given a flavor-id by cli or config-option, If the specified flavor is present in Octavia, that flavor will be returned for applying to the LB
        - Given a flavor-id by cli or config-option, If the specified flavor is not present in Octavia, then the LB migration will be skipped with a message as **"Skipping the migration as the specified flavor cannot be found"**
        - If a flavor-id is not specified by cli or config option, then a flavor will be generated and then will get returned to apply to the LB
- If `--flavor-id` is specified without `--lb-id`, then an error `"Error: --lb-id should be specified with --flavor-id"` will be thrown.
- If `--flavor-id` is specified with `--all` or `--project-id` option, then an error `"Error: --flavor-id can only be used in conjunction with --lb-id"` will be thrown.
- Flavor IDs present in `flavor_id_list` will be applied parallely to LBs in the `lb_id_list`
- If `flavor_id_list` holds less entries than that of `lb_id_list`, then new flavors will be generated for applying to the extra values in `lb_id_list`.
- If `flavor_id_list` holds less entries than that of `lb_id_list` and `default_flavor_id` is also specified in the config, then the flavor with id as `default_flavor_id` will get applied to the extra entries in `lb_id_list`.
- If `flavor_id_list` holds more entries than that of `lb_id_list`, then an error `"Error: flavor_id_list cannot be mapped with lb_id_list as flavor_id_list holds more entries than lb_id_list"` will be thrown.


## Testing Info:
Following are the possible ways to use all the 3 flavor-id specification options:

Create 10 LBs using a10-neutron-lbaas
stack@rahul:~$ neutron lbaas-loadbalancer-list
neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| id                                   | name | tenant_id                        | vip_address | provisioning_status | provider    |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  | 3c96f64028784b959fca91b646983cda | 10.0.14.195 | ACTIVE              | a10networks |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10networks |
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10networks |
| 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  | 3c96f64028784b959fca91b646983cda | 10.0.13.199 | ACTIVE              | a10networks |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10networks |
| b854eda3-6892-4a93-8c00-ff0f5b9acb6b | lb2  | 3c96f64028784b959fca91b646983cda | 10.0.12.188 | ACTIVE              | a10networks |
| dd0d27ea-7a3b-4b44-b5e9-0548964842f2 | lb9  | 3c96f64028784b959fca91b646983cda | 10.0.11.117 | ACTIVE              | a10networks |
| e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  | 3c96f64028784b959fca91b646983cda | 10.0.12.181 | ACTIVE              | a10networks |
| f1402ae6-9d8b-47b2-b9b8-54bb36253a92 | lb10 | 3c96f64028784b959fca91b646983cda | 10.0.12.143 | ACTIVE              | a10networks |
| fb3d0719-ac3a-4a31-930c-22f8edf5113f | lb4  | 3c96f64028784b959fca91b646983cda | 10.0.14.110 | ACTIVE              | a10networks |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
```
**1. Migrate lb1 with --flavor-id c4534438-8c8e-4489-aada-661d0bbde666 where the flavor exists in Octavia.**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id 72fcfe71-051a-42fe-9765-e717fd2a4314 --flavor-id c4534438-8c8e-4489-aada-661d0bbde666

mysql> select * from load_balancer;
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```
1 row in set (0.00 sec)


stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+

```

**2. Migrate lb2 with --flavor-id 8254ed45-1072-4b33-1c90-120f5b9acb12 where the flavor does not exist in Octavia**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id b854eda3-6892-4a93-8c00-ff0f5b9acb6b --flavor-id 8254ed45-1072-4b33-1c90-120f5b9acb12

The LB will not get migrated and will give a message as "Skipping the migration as the specified flavor cannot be found"


stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

**3. Migrate lb3 with default_flavor_id=c4534438-8c8e-4489-aada-661d0bbde666 in config file a10_nlbaas2oct.conf, where the flavor exists in Octavia.**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id 57c1cb08-f13b-4129-9dea-1714d703be84

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

mysql> select * from load_balancer;                                                                                                         
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**4. Migrate lb4 with default_flavor_id=8a434456-4c7e-3889-a167-ac1d0bbde786 in config file a10_nlbaas2oct.conf, where the flavor does not exist in Octavia.**

stack@rahul:~$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id fb3d0719-ac3a-4a31-930c-22f8edf5113f                                

The LB will not get migrated and will give a message as "Skipping the migration as the specified flavor cannot be found"

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

**5. Migrate lb5 with --flavor-id as 5b129795-842b-49da-b20b-4ebcf1ad3390 and also default_flavor_id=8a434456-4c7e-3889-a167-ac1d0bbde786 in a10_nlbaas2oct.conf**

**In this case, --flavor-id will take precedence than default_flavor_id.**

stack@rahul:~$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id 774fba79-d6df-4def-a992-19b322ddcf7e --flavor-id 5b129795-842b-49da-b20b-4ebcf1ad3390

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

mysql> select * from load_balancer;
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:03:41 | 2021-08-18 14:03:41 | a10      | 5b129795-842b-49da-b20b-4ebcf1ad3390 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**6. Migrate lb6 without --flavor-id as well as without default_flavor_id or flavor_id_list**

**In this case, a new flavorprofile and flavor will get generated to get attached with lb6.**

stack@rahul:~$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --lb-id e4956cd0-3698-4c73-a971-ccc055142e3d

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10      |
| e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  | 3c96f64028784b959fca91b646983cda | 10.0.12.181 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

mysql> select * from load_balancer;
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:03:41 | 2021-08-18 14:03:41 | a10      | 5b129795-842b-49da-b20b-4ebcf1ad3390 |
| 3c96f64028784b959fca91b646983cda | e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:06:40 | 2021-08-18 14:06:40 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**7. Migrate lb7 and lb8 with below config:
lb_id_list = 770a9cad-7fcb-4f50-891a-51121b1fb488, 047a3cce-de97-4218-99de-6bd1385f18b4
flavor_id_list = c4534438-8c8e-4489-aada-661d0bbde666, 44b74797-5598-4f87-97b0-52f81ac10856**

Both the flavors exists in Octavia.

**In this case, flavor c4534438-8c8e-4489-aada-661d0bbde666 will be applied to lb 770a9cad-7fcb-4f50-891a-51121b1fb488 and flavor 44b74797-5598-4f87-97b0-52f81ac10856 will be applied to lb 047a3cce-de97-4218-99de-6bd1385f18b4**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10      |
| e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  | 3c96f64028784b959fca91b646983cda | 10.0.12.181 | ACTIVE              | a10      |
| 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  | 3c96f64028784b959fca91b646983cda | 10.0.14.195 | ACTIVE              | a10      |
| 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  | 3c96f64028784b959fca91b646983cda | 10.0.13.199 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

mysql> select * from load_balancer;                                                                                                         
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:43 | 2021-08-18 14:24:43 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:30 | 2021-08-18 14:24:30 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:03:41 | 2021-08-18 14:03:41 | a10      | 5b129795-842b-49da-b20b-4ebcf1ad3390 |
| 3c96f64028784b959fca91b646983cda | e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:06:40 | 2021-08-18 14:06:40 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**8. Migrate lb9 and lb10 with below config:
lb_id_list = dd0d27ea-7a3b-4b44-b5e9-0548964842f2, f1402ae6-9d8b-47b2-b9b8-54bb36253a92
flavor_id_list = a41b0900-8182-4aa5-45e0-a27c48c18123, a5534608-8abe-1209-6ada-1a1d0bbd7856**

Both the flavors are not in Octavia.

The LBs will not get migrated and will give a message as "Skipping the migration as the specified flavor cannot be found"

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf

Create some new LBs by a10-neutron-lbaas using a10-neutron-lbaas.

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ neutron lbaas-loadbalancer-list
neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| id                                   | name | tenant_id                        | vip_address | provisioning_status | provider    |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| 0cdc00b5-9693-449c-ad4a-fae692f621b4 | lb13 | 3c96f64028784b959fca91b646983cda | 10.0.13.137 | ACTIVE              | a10networks |
| 2237bf83-8c12-4a32-a2db-ebfe46f6d83f | lb15 | 3c96f64028784b959fca91b646983cda | 10.0.11.150 | ACTIVE              | a10networks |
| 6c285b7e-ae35-4d92-b774-6a3e8ac58630 | lb17 | 3c96f64028784b959fca91b646983cda | 10.0.13.200 | ACTIVE              | a10networks |
| 82eb311a-de88-4903-9d9e-f601c3314e2b | lb18 | 3c96f64028784b959fca91b646983cda | 10.0.14.103 | ACTIVE              | a10networks |
| 88323456-5c3f-455d-9066-50440a56a07c | lb14 | 3c96f64028784b959fca91b646983cda | 10.0.14.172 | ACTIVE              | a10networks |
| 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad | lb12 | 3c96f64028784b959fca91b646983cda | 10.0.12.125 | ACTIVE              | a10networks |
| c55c9a93-76ca-4887-9a86-157f0aab3444 | lb16 | 3c96f64028784b959fca91b646983cda | 10.0.12.197 | ACTIVE              | a10networks |
| fd2cc4e7-5703-41fe-a00c-b010f0041dad | lb11 | 3c96f64028784b959fca91b646983cda | 10.0.11.174 | ACTIVE              | a10networks |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+

```

**9. Migrate lb11 and lb12 with below config:
lb_id_list = fd2cc4e7-5703-41fe-a00c-b010f0041dad, 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad
flavor_id_list = c4534438-8c8e-4489-aada-661d0bbde666
default_flavor_id = 8a434456-4c7e-3889-a167-ac1d0bbde786**

**In this case, flavor c4534438-8c8e-4489-aada-661d0bbde666 will be applied to fd2cc4e7-5703-41fe-a00c-b010f0041dad and the default flavor 8a434456-4c7e-3889-a167-ac1d0bbde786 will be applied to 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10      |
| e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  | 3c96f64028784b959fca91b646983cda | 10.0.12.181 | ACTIVE              | a10      |
| 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  | 3c96f64028784b959fca91b646983cda | 10.0.13.199 | ACTIVE              | a10      |
| 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  | 3c96f64028784b959fca91b646983cda | 10.0.14.195 | ACTIVE              | a10      |
| 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad | lb12 | 3c96f64028784b959fca91b646983cda | 10.0.12.125 | ACTIVE              | a10      |
| fd2cc4e7-5703-41fe-a00c-b010f0041dad | lb11 | 3c96f64028784b959fca91b646983cda | 10.0.11.174 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```


mysql> select * from load_balancer;                                                                                                         
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:43 | 2021-08-18 14:24:43 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:30 | 2021-08-18 14:24:30 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:03:41 | 2021-08-18 14:03:41 | a10      | 5b129795-842b-49da-b20b-4ebcf1ad3390 |
| 3c96f64028784b959fca91b646983cda | 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad | lb12 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:05:23 | 2021-08-20 06:05:23 | a10      | 8a434456-4c7e-3889-a167-ac1d0bbde786 |
| 3c96f64028784b959fca91b646983cda | e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:06:40 | 2021-08-18 14:06:40 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
| 3c96f64028784b959fca91b646983cda | fd2cc4e7-5703-41fe-a00c-b010f0041dad | lb11 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:05:23 | 2021-08-20 06:05:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**10. Migrate lb13 and lb14 with below config:
lb_id_list = 0cdc00b5-9693-449c-ad4a-fae692f621b4, 88323456-5c3f-455d-9066-50440a56a07c
flavor_id_list = a41b0900-8182-4aa5-45e0-a27c48c18123**

**In this case, flavor a41b0900-8182-4aa5-45e0-a27c48c18123 will be applied to lb 0cdc00b5-9693-449c-ad4a-fae692f621b4 and a new flavor will get generated and applied to lb 88323456-5c3f-455d-9066-50440a56a07c**

stack@rahul:~$ openstack loadbalancer list
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| id                                   | name | project_id                       | vip_address | provisioning_status | provider |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
| 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  | 3c96f64028784b959fca91b646983cda | 10.0.11.146 | ACTIVE              | a10      |
| 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  | 3c96f64028784b959fca91b646983cda | 10.0.13.197 | ACTIVE              | a10      |
| 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  | 3c96f64028784b959fca91b646983cda | 10.0.11.108 | ACTIVE              | a10      |
| e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  | 3c96f64028784b959fca91b646983cda | 10.0.12.181 | ACTIVE              | a10      |
| 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  | 3c96f64028784b959fca91b646983cda | 10.0.13.199 | ACTIVE              | a10      |
| 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  | 3c96f64028784b959fca91b646983cda | 10.0.14.195 | ACTIVE              | a10      |
| 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad | lb12 | 3c96f64028784b959fca91b646983cda | 10.0.12.125 | ACTIVE              | a10      |
| fd2cc4e7-5703-41fe-a00c-b010f0041dad | lb11 | 3c96f64028784b959fca91b646983cda | 10.0.11.174 | ACTIVE              | a10      |
| 0cdc00b5-9693-449c-ad4a-fae692f621b4 | lb13 | 3c96f64028784b959fca91b646983cda | 10.0.13.137 | ACTIVE              | a10      |
| 88323456-5c3f-455d-9066-50440a56a07c | lb14 | 3c96f64028784b959fca91b646983cda | 10.0.14.172 | ACTIVE              | a10      |
+--------------------------------------+------+----------------------------------+-------------+---------------------+----------+
```

mysql> select * from load_balancer;                                                                                                         
```
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| project_id                       | id                                   | name | description | provisioning_status | operating_status | enabled | topology | server_group_id | created_at          | updated_at          | provider | flavor_id                            |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
| 3c96f64028784b959fca91b646983cda | 047a3cce-de97-4218-99de-6bd1385f18b4 | lb8  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:43 | 2021-08-18 14:24:43 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
| 3c96f64028784b959fca91b646983cda | 0cdc00b5-9693-449c-ad4a-fae692f621b4 | lb13 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:15:03 | 2021-08-20 06:15:03 | a10      | a41b0900-8182-4aa5-45e0-a27c48c18123 |
| 3c96f64028784b959fca91b646983cda | 57c1cb08-f13b-4129-9dea-1714d703be84 | lb3  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 10:42:18 | 2021-08-18 10:42:18 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 72fcfe71-051a-42fe-9765-e717fd2a4314 | lb1  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 06:40:23 | 2021-08-18 06:40:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 770a9cad-7fcb-4f50-891a-51121b1fb488 | lb7  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:24:30 | 2021-08-18 14:24:30 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
| 3c96f64028784b959fca91b646983cda | 774fba79-d6df-4def-a992-19b322ddcf7e | lb5  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:03:41 | 2021-08-18 14:03:41 | a10      | 5b129795-842b-49da-b20b-4ebcf1ad3390 |
| 3c96f64028784b959fca91b646983cda | 88323456-5c3f-455d-9066-50440a56a07c | lb14 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:15:03 | 2021-08-20 06:15:03 | a10      | 2f43a8db-62a5-4879-892f-eee12ca823d2 |
| 3c96f64028784b959fca91b646983cda | 8cc4ff96-f1b8-4284-bcda-0f89c2a207ad | lb12 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:05:23 | 2021-08-20 06:05:23 | a10      | 8a434456-4c7e-3889-a167-ac1d0bbde786 |
| 3c96f64028784b959fca91b646983cda | e4956cd0-3698-4c73-a971-ccc055142e3d | lb6  |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-18 14:06:40 | 2021-08-18 14:06:40 | a10      | 44b74797-5598-4f87-97b0-52f81ac10856 |
| 3c96f64028784b959fca91b646983cda | fd2cc4e7-5703-41fe-a00c-b010f0041dad | lb11 |             | ACTIVE              | ONLINE           |       1 | SINGLE   | NULL            | 2021-08-20 06:05:23 | 2021-08-20 06:05:23 | a10      | c4534438-8c8e-4489-aada-661d0bbde666 |
+----------------------------------+--------------------------------------+------+-------------+---------------------+------------------+---------+----------+-----------------+---------------------+---------------------+----------+--------------------------------------+
```

**11. Cleanup the lb11, lb12, lb13 and lb14 from a10-neutron-lbaas side and then perform Migration with --flavor-id a41b0900-8182-4aa5-45e0-a27c48c18123 and --all option**

stack@rahul:~$ neutron lbaas-loadbalancer-list
neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| id                                   | name | tenant_id                        | vip_address | provisioning_status | provider    |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| 2237bf83-8c12-4a32-a2db-ebfe46f6d83f | lb15 | 3c96f64028784b959fca91b646983cda | 10.0.11.150 | ACTIVE              | a10networks |
| 6c285b7e-ae35-4d92-b774-6a3e8ac58630 | lb17 | 3c96f64028784b959fca91b646983cda | 10.0.13.200 | ACTIVE              | a10networks |
| 82eb311a-de88-4903-9d9e-f601c3314e2b | lb18 | 3c96f64028784b959fca91b646983cda | 10.0.14.103 | ACTIVE              | a10networks |
| c55c9a93-76ca-4887-9a86-157f0aab3444 | lb16 | 3c96f64028784b959fca91b646983cda | 10.0.12.197 | ACTIVE              | a10networks |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
```

**In this case, an error msg will be displayed as the --flavor-id option can be used only with --lb-id option**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --all --flavor-id a41b0900-8182-4aa5-45e0-a27c48c18123

**Error: --lb-id should be specified with --flavor-id**


**12. Perform Migration with --flavor-id a41b0900-8182-4aa5-45e0-a27c48c18123 and --project-id option**

stack@rahul:~$ neutron lbaas-loadbalancer-list
neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
```
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| id                                   | name | tenant_id                        | vip_address | provisioning_status | provider    |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
| 2237bf83-8c12-4a32-a2db-ebfe46f6d83f | lb15 | 3c96f64028784b959fca91b646983cda | 10.0.11.150 | ACTIVE              | a10networks |
| 6c285b7e-ae35-4d92-b774-6a3e8ac58630 | lb17 | 3c96f64028784b959fca91b646983cda | 10.0.13.200 | ACTIVE              | a10networks |
| 82eb311a-de88-4903-9d9e-f601c3314e2b | lb18 | 3c96f64028784b959fca91b646983cda | 10.0.14.103 | ACTIVE              | a10networks |
| c55c9a93-76ca-4887-9a86-157f0aab3444 | lb16 | 3c96f64028784b959fca91b646983cda | 10.0.12.197 | ACTIVE              | a10networks |
+--------------------------------------+------+----------------------------------+-------------+---------------------+-------------+
```

**In this case, an error msg will be displayed as the --flavor-id option can be used only with --lb-id option**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf --project-id 3c96f64028784b959fca91b646983cda --flavor-id a41b0900-8182-4aa5-45e0-a27c48c18123

**Error: --lb-id should be specified with --flavor-id**


**13. Migrate lb15 and lb16 with below config:
lb_id_list = 2237bf83-8c12-4a32-a2db-ebfe46f6d83f, c55c9a93-76ca-4887-9a86-157f0aab3444
flavor_id_list = a41b0900-8182-4aa5-45e0-a27c48c18123, 8a434456-4c7e-3889-a167-ac1d0bbde786, 44b74797-5598-4f87-97b0-52f81ac10856**

**In this case, as the flavor_id_list is having more values that that of lb_id_list, en error will be thrown.
Error: flavor_id_list cannot be mapped with lb_id_list as flavor_id_list holds more entries than lb_id_list**

stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ a10_nlbaas2oct --config-file a10_nlbaas2oct.conf

**Error: flavor_id_list cannot be mapped with lb_id_list as flavor_id_list holds more entries than lb_id_list**