### PR TITLE
[BUG][STACK-2838]: Raising an exception if an invalid flavor_id is specified in flavor_id_list

### DIFF
--- a/a10_nlbaas2oct/driver.py
+++ b/a10_nlbaas2oct/driver.py
@@ -114,7 +114,7 @@ def _flavor_id_validation(LOG, o_session, flavor_id):
         raise Exception
 
     if not fl_id:
-        raise Exception(_('Flavor id %s is not exist.'), fl_id)
+        raise Exception(_('This flavor id does not exist:'), flavor_id)
 
 def _flavor_selection(LOG, a10_config, o_session, lb_id, flavor_list, flavor_idx, dev_flavor_map, device_name):
     # --flavor-id should have highest priority (even than flavor_id_list)
@@ -124,6 +124,7 @@ def _flavor_selection(LOG, a10_config, o_session, lb_id, flavor_list, flavor_idx
 
     if CONF.migration.flavor_id_list and CONF.migration.lb_id_list:
         if len(flavor_list) > flavor_idx:
+            _flavor_id_validation(LOG, o_session, flavor_list[flavor_idx])
             return flavor_list[flavor_idx]
 
     if CONF.migration.default_flavor_id:


### PR DESCRIPTION
## Description
If an invalid flavor_id i.e the flavor_id which does not exist in advance is specified in flavor_id_list for using with the LB in lb_id_list, then it should raise an exception instead of attaching it to the LB.

## Jira ticket
https://a10networks.atlassian.net/browse/STACK-2838

## Technical Approach
- Calling `_flavor_id_validation(LOG, o_session, flavor_list[flavor_idx])` before returning the `flavor_list[flavor_idx]` to check whether the `flavor_list[flavor_idx]` exists in DB or not and to raise an exception if it does not exist.

## Testing
1. Create a loadbalancer

stack@rahul:~$ **neutron lbaas-loadbalancer-create --name lbl provider-vlan-12-subnet**
neutron CLI is deprecated and will be removed in the future. Use openstack CLI instead.
Created a new loadbalancer:
```
+---------------------+--------------------------------------+
| Field               | Value                                |
+---------------------+--------------------------------------+
| admin_state_up      | True                                 |
| description         |                                      |
| id                  | 4f2b67ab-1925-4a7e-9832-e5324a56efb3 |
| listeners           |                                      |
| name                | lbl                                  |
| operating_status    | ONLINE                               |
| pools               |                                      |
| provider            | a10networks                          |
| provisioning_status | ACTIVE                               |
| tenant_id           | 3c96f64028784b959fca91b646983cda     |
| vip_address         | 10.0.12.141                          |
| vip_port_id         | 566b4f2b-4c7d-4488-85ba-3156577cd4db |
| vip_subnet_id       | e3f590f7-4e57-4127-aa4f-5471f7ba1a5f |
+---------------------+--------------------------------------+
```

2. Configure an invalid flavor_id 123eef93-cc1d-446f-923c-ae4e351b2123  in the flavor_id_list in a10_nlbaas2oct.conf,  which does not exist in octavia DB

```
[DEFAULT]
debug = True
[migration]
octavia_account_id = admin
neutron_db_connection = mysql+pymysql://root:password@127.0.0.1/neutron?charset=utf8
octavia_db_connection = mysql+pymysql://root:password@127.0.0.1/octavia?charset=utf8
keystone_db_connection = mysql+pymysql://root:password@127.0.0.1/keystone?charset=utf8
a10_config_path = /etc/a10/config.py
lb_id_list = 4f2b67ab-1925-4a7e-9832-e5324a56efb3
flavor_id_list = 123eef93-cc1d-446f-923c-ae4e351b2123
```

3. Perform migration
stack@rahul:~/neha/a10-nlbaas2oct/a10_nlbaas2oct$ **a10_nlbaas2oct --config-file a10_nlbaas2oct.conf**

2021-08-31 11:11:55.056 1207 DEBUG a10_nlbaas2oct [-] ******************************************************************************** log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2553
2021-08-31 11:11:55.057 1207 DEBUG a10_nlbaas2oct [-] Configuration options gathered from: log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2554
2021-08-31 11:11:55.057 1207 DEBUG a10_nlbaas2oct [-] command line args: ['--config-file', 'a10_nlbaas2oct.conf'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2555
2021-08-31 11:11:55.057 1207 DEBUG a10_nlbaas2oct [-] config files: ['a10_nlbaas2oct.conf'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2557
2021-08-31 11:11:55.057 1207 DEBUG a10_nlbaas2oct [-] ================================================================================ log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2558
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] agent_down_time                = 75 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] all                            = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] allow_bulk                     = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] allow_overlapping_ips          = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] api_extensions_path            =  log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.058 1207 DEBUG a10_nlbaas2oct [-] api_paste_config               = api-paste.ini log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.059 1207 DEBUG a10_nlbaas2oct [-] auth_strategy                  = keystone log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.059 1207 DEBUG a10_nlbaas2oct [-] backlog                        = 4096 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.059 1207 DEBUG a10_nlbaas2oct [-] base_mac                       = fa:16:3e:00:00:00 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.059 1207 DEBUG a10_nlbaas2oct [-] bind_host                      = 0.0.0.0 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.059 1207 DEBUG a10_nlbaas2oct [-] bind_port                      = 9696 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] cleanup                        = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] client_socket_timeout          = 900 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] config_dir                     = [] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] config_file                    = ['a10_nlbaas2oct.conf'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] config_source                  = [] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] core_plugin                    = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.060 1207 DEBUG a10_nlbaas2oct [-] debug                          = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.061 1207 DEBUG a10_nlbaas2oct [-] default_availability_zones     = [] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.061 1207 DEBUG a10_nlbaas2oct [-] default_log_levels             = ['amqp=WARN', 'amqplib=WARN', 'boto=WARN', 'qpid=WARN', 'sqlalchemy=WARN', 'suds=INFO', 'oslo.messaging=INFO', 'oslo_messaging=INFO', 'iso8601=WARN', 'requests.packages.urllib3.connectionpool=WARN', 'urllib3.connectionpool=WARN', 'websocket=WARN', 'requests.packages.urllib3.util.retry=WARN', 'urllib3.util.retry=WARN', 'keystonemiddleware=WARN', 'routes.middleware=WARN', 'stevedore=WARN', 'taskflow=WARN', 'keystoneauth=WARN', 'oslo.cache=INFO', 'oslo_policy=INFO', 'dogpile.core.dogpile=INFO'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.061 1207 DEBUG a10_nlbaas2oct [-] dhcp_agent_notification        = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.061 1207 DEBUG a10_nlbaas2oct [-] dhcp_lease_duration            = 86400 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.061 1207 DEBUG a10_nlbaas2oct [-] dhcp_load_type                 = networks log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] dns_domain                     = openstacklocal log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] enable_new_agents              = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] external_dns_driver            = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] filter_validation              = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] flavor_id                      = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.062 1207 DEBUG a10_nlbaas2oct [-] global_physnet_mtu             = 1500 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] host                           = rahul log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] http_retries                   = 3 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] instance_format                = [instance: %(uuid)s]  log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] instance_uuid_format           = [instance: %(uuid)s]  log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] ipam_driver                    = internal log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.063 1207 DEBUG a10_nlbaas2oct [-] ipv6_pd_enabled                = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] lb_id                          = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_config_append              = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_date_format                = %Y-%m-%d %H:%M:%S log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_dir                        = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_file                       = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_rotate_interval            = 1 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.064 1207 DEBUG a10_nlbaas2oct [-] log_rotate_interval_type       = days log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] log_rotation_type              = none log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] logging_context_format_string  = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] logging_debug_format_suffix    = %(funcName)s %(pathname)s:%(lineno)d log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] logging_default_format_string  = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] logging_exception_prefix       = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.065 1207 DEBUG a10_nlbaas2oct [-] logging_user_identity_format   = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] max_dns_nameservers            = 5 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] max_header_line                = 16384 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] max_logfile_count              = 30 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] max_logfile_size_mb            = 200 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] max_subnet_host_routes         = 20 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.066 1207 DEBUG a10_nlbaas2oct [-] network_link_prefix            = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] notify_nova_on_port_data_changes = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] notify_nova_on_port_status_changes = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] pagination_max_limit           = -1 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] project_id                     = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] publish_errors                 = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.067 1207 DEBUG a10_nlbaas2oct [-] rate_limit_burst               = 0 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] rate_limit_except_level        = CRITICAL log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] rate_limit_interval            = 0 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] retry_until_window             = 30 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] send_events_interval           = 2 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] service_plugins                = [] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.068 1207 DEBUG a10_nlbaas2oct [-] setproctitle                   = on log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] state_path                     = /var/lib/neutron log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] syslog_log_facility            = LOG_USER log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] tcp_keepidle                   = 600 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] use_eventlog                   = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] use_journal                    = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] use_json                       = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.069 1207 DEBUG a10_nlbaas2oct [-] use_ssl                        = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] use_stderr                     = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] use_syslog                     = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] vlan_transparent               = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] watch_log_file                 = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] wsgi_default_pool_size         = 100 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] wsgi_keep_alive                = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.070 1207 DEBUG a10_nlbaas2oct [-] wsgi_log_format                = %(client_ip)s "%(request_line)s" status: %(status_code)s  len: %(body_length)s time: %(wall_seconds).7f log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2567
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.a10_config_path      = /etc/a10/config.py log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.a10_nlbaas_db_connection = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.a10_oct_db_connection = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.default_flavor_id    = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.delete_after_migration = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.071 1207 DEBUG a10_nlbaas2oct [-] migration.flavor_id_list       = ['123eef93-cc1d-446f-923c-ae4e351b2123'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.ignore_l7rule_status = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.keystone_db_connection = mysql+pymysql://root:password@127.0.0.1/keystone?charset=utf8 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.lb_id_list           = ['4f2b67ab-1925-4a7e-9832-e5324a56efb3'] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.neutron_db_connection = mysql+pymysql://root:password@127.0.0.1/neutron?charset=utf8 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.octavia_account_id   = admin log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.octavia_db_connection = mysql+pymysql://root:password@127.0.0.1/octavia?charset=utf8 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.072 1207 DEBUG a10_nlbaas2oct [-] migration.provider_name        = a10networks log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.073 1207 DEBUG a10_nlbaas2oct [-] migration.trial_run            = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.073 1207 DEBUG a10_nlbaas2oct [-] service_providers.service_provider = [] log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.073 1207 DEBUG a10_nlbaas2oct [-] placement.auth_section         = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.073 1207 DEBUG a10_nlbaas2oct [-] placement.auth_type            = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.073 1207 DEBUG a10_nlbaas2oct [-] placement.cafile               = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.certfile             = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.collect_timing       = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.endpoint_type        = public log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.insecure             = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.keyfile              = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.074 1207 DEBUG a10_nlbaas2oct [-] placement.region_name          = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] placement.split_loggers        = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] placement.timeout              = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.default_quota           = -1 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_driver            = neutron.db.quota.driver.DbQuotaDriver log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_floatingip        = 50 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.075 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_network           = 100 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_port              = 500 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_router            = 10 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_security_group    = 10 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_security_group_rule = 100 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.quota_subnet            = 100 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.076 1207 DEBUG a10_nlbaas2oct [-] QUOTAS.track_quota_usage       = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.077 1207 DEBUG a10_nlbaas2oct [-] nova.auth_section              = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.077 1207 DEBUG a10_nlbaas2oct [-] nova.auth_type                 = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.077 1207 DEBUG a10_nlbaas2oct [-] nova.cafile                    = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.077 1207 DEBUG a10_nlbaas2oct [-] nova.certfile                  = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.077 1207 DEBUG a10_nlbaas2oct [-] nova.collect_timing            = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.endpoint_type             = public log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.insecure                  = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.keyfile                   = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.region_name               = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.split_loggers             = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.078 1207 DEBUG a10_nlbaas2oct [-] nova.timeout                   = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.connection_string     = messaging:// log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.enabled               = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.es_doc_type           = notification log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.es_scroll_size        = 10000 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.es_scroll_time        = 2m log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.079 1207 DEBUG a10_nlbaas2oct [-] profiler.filter_error_trace    = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.080 1207 DEBUG a10_nlbaas2oct [-] profiler.hmac_keys             = SECRET_KEY log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.080 1207 DEBUG a10_nlbaas2oct [-] profiler.sentinel_service_name = mymaster log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.080 1207 DEBUG a10_nlbaas2oct [-] profiler.socket_timeout        = 0.1 log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.080 1207 DEBUG a10_nlbaas2oct [-] profiler.trace_sqlalchemy      = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.080 1207 DEBUG a10_nlbaas2oct [-] AGENT.root_helper              = sudo log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.081 1207 DEBUG a10_nlbaas2oct [-] AGENT.root_helper_daemon       = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.081 1207 DEBUG a10_nlbaas2oct [-] AGENT.use_helper_for_ns_read   = True log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.081 1207 DEBUG a10_nlbaas2oct [-] xenapi.connection_password     = **** log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.774 1207 DEBUG a10_nlbaas2oct [-] xenapi.connection_url          = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.775 1207 DEBUG a10_nlbaas2oct [-] xenapi.connection_username     = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.775 1207 DEBUG a10_nlbaas2oct [-] oslo_versionedobjects.fatal_exception_format_errors = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.775 1207 DEBUG a10_nlbaas2oct [-] oslo_concurrency.disable_process_locking = False log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.775 1207 DEBUG a10_nlbaas2oct [-] oslo_concurrency.lock_path     = None log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2575
2021-08-31 11:11:55.775 1207 DEBUG a10_nlbaas2oct [-] ******************************************************************************** log_opt_values /usr/local/lib/python2.7/dist-packages/oslo_config/cfg.py:2577
2021-08-31 11:11:55.775 1207 INFO a10_nlbaas2oct [-] === Starting migration ===
2021-08-31 11:11:55.805 1207 DEBUG oslo_db.sqlalchemy.engines [-] MySQL server mode set to STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,TRADITIONAL,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION _check_effective_sql_mode /usr/local/lib/python2.7/dist-packages/oslo_db/sqlalchemy/engines.py:307
2021-08-31 11:11:55.827 1207 DEBUG oslo_db.sqlalchemy.engines [-] MySQL server mode set to STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,TRADITIONAL,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION _check_effective_sql_mode /usr/local/lib/python2.7/dist-packages/oslo_db/sqlalchemy/engines.py:307
2021-08-31 11:11:55.847 1207 DEBUG oslo_db.sqlalchemy.engines [-] MySQL server mode set to STRICT_TRANS_TABLES,STRICT_ALL_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,TRADITIONAL,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION _check_effective_sql_mode /usr/local/lib/python2.7/dist-packages/oslo_db/sqlalchemy/engines.py:307
2021-08-31 11:11:55.850 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default database_connection=None _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.850 1207 DEBUG a10_nlbaas2oct.a10_config [-] global setting keystone_version=3 _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:107
2021-08-31 11:11:55.850 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default neutron_conf_dir=/etc/neutron _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.850 1207 DEBUG a10_nlbaas2oct.a10_config [-] global setting use_database=True _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:107
2021-08-31 11:11:55.851 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default plumbing_hooks_class=<class 'a10_neutron_lbaas.plumbing.simple.PlumbingHooks'> _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.851 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default nova_api_version=2.1 _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.851 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default verify_appliances=False _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.851 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default vport_defaults={} _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.851 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default member_name_use_uuid=False _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.852 1207 DEBUG a10_nlbaas2oct.a10_config [-] setting global default use_parent_project=False _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:104
2021-08-31 11:11:55.852 1207 DEBUG a10_nlbaas2oct.a10_config [-] global setting keystone_auth_url=http://10.64.3.149/identity/v3 _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:107
2021-08-31 11:11:55.852 1207 DEBUG a10_nlbaas2oct.a10_config [-] A10Config, device ax1={'username': 'admin', 'status': True, 'protocol': 'https', 'host': '10.64.3.111', 'key': 'ax1', 'ipinip': False, 'ha_sync_list': [], 'password': 'a10', 'port': 443, 'name': 'ax1', 'vport_defaults': {}, 'shared_partition': 'shared', 'default_virtual_server_vrid': None, 'v_method': 'LSI', 'autosnat': True, 'use_float': False, 'write_memory': True, 'api_version': '3.0'} _load_config /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:142
2021-08-31 11:11:55.853 1207 DEBUG a10_nlbaas2oct.a10_config [-] found neutron.conf file in /etc _get_neutron_conf /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:220
2021-08-31 11:11:55.856 1207 DEBUG a10_nlbaas2oct.a10_config [-] using mysql+pymysql://root:password@127.0.0.1/neutron?charset=utf8 as db connect string _get_neutron_db_string /usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/a10_config.py:234
2021-08-31 11:11:55.858 1207 INFO a10_nlbaas2oct [-] Locking Neutron LBaaS load balancer: 4f2b67ab-1925-4a7e-9832-e5324a56efb3
2021-08-31 11:11:55.862 1207 INFO a10_nlbaas2oct [-] Migrating Thunder config entry ax1 with name ax1
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct [-] Skipping load balancer 4f2b67ab-1925-4a7e-9832-e5324a56efb3 due to: (u'This flavor id does not exist:', '123eef93-cc1d-446f-923c-ae4e351b2123').: Exception: (u'This flavor id does not exist:', '123eef93-cc1d-446f-923c-ae4e351b2123')
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct Traceback (most recent call last):
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct   File "/usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/driver.py", line 505, in main
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct     lb_idx, flavor_map, device_name)
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct   File "/usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/driver.py", line 127, in _flavor_selection
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct     _flavor_id_validation(LOG, o_session, flavor_list[flavor_idx])
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct   File "/usr/local/lib/python2.7/dist-packages/a10_nlbaas2oct/driver.py", line 117, in _flavor_id_validation
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct     raise Exception(_('This flavor id does not exist:'), flavor_id)
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct Exception: (u'This flavor id does not exist:', '123eef93-cc1d-446f-923c-ae4e351b2123')
2021-08-31 11:11:55.868 1207 ERROR a10_nlbaas2oct
2021-08-31 11:11:55.869 1207 INFO a10_nlbaas2oct [-] Unlocking Neutron LBaaS load balancer: 4f2b67ab-1925-4a7e-9832-e5324a56efb3
2021-08-31 11:11:55.871 1207 WARNING a10_nlbaas2oct [-] 1 failures were detected: **Exception: (u'This flavor id does not exist:', '123eef93-cc1d-446f-923c-ae4e351b2123')**
